### PR TITLE
Updated AbstractCommand::catchException() when re-throwing the exception...

### DIFF
--- a/src/Aura/Cli/AbstractCommand.php
+++ b/src/Aura/Cli/AbstractCommand.php
@@ -306,6 +306,8 @@ abstract class AbstractCommand
             // set the return code
             $this->setReturn($e->getCode());
 
+            // done
+            return;
         }
 
         // throw the exception

--- a/src/Aura/Cli/AbstractCommand.php
+++ b/src/Aura/Cli/AbstractCommand.php
@@ -314,6 +314,6 @@ abstract class AbstractCommand
         // not a message-only exception. throw a copy, with the original as
         // the previous exception so that we can see a full trace.
         $class = get_class($e);
-        throw new $class($e->getMessage(), $e->getCode(), $e);
+        throw new $class($e->getMessage(), (int)$e->getCode(), $e);
     }
 }

--- a/src/Aura/Cli/AbstractCommand.php
+++ b/src/Aura/Cli/AbstractCommand.php
@@ -306,11 +306,10 @@ abstract class AbstractCommand
             // set the return code
             $this->setReturn($e->getCode());
 
-            // done
             return;
+
         }
 
-        // throw the exception
         throw $e;
     }
 }

--- a/src/Aura/Cli/AbstractCommand.php
+++ b/src/Aura/Cli/AbstractCommand.php
@@ -178,7 +178,7 @@ abstract class AbstractCommand
             $this->signal->send($this, 'post_exec', $this);
             
         } catch (Exception $exception) {
-            
+
             // set the exception and send a signal
             $this->exception = $exception;
             $this->signal->send($this, 'catch_exception', $this);
@@ -305,15 +305,10 @@ abstract class AbstractCommand
             
             // set the return code
             $this->setReturn($e->getCode());
-            
-            // done
-            return;
-            
+
         }
-        
-        // not a message-only exception. throw a copy, with the original as
-        // the previous exception so that we can see a full trace.
-        $class = get_class($e);
-        throw new $class($e->getMessage(), (int)$e->getCode(), $e);
+
+        // throw the exception
+        throw $e;
     }
 }


### PR DESCRIPTION
... to cast the exception's code to an int

Find it the hard way when creating a Cli App using PDO. The Pdo was throwing an exception with code `HY093` - which is not numeric. So... just in case :-)
