### PR TITLE
Fix in for getopt alias ordering

### DIFF
--- a/src/Context/Getopt.php
+++ b/src/Context/Getopt.php
@@ -446,4 +446,31 @@ class Getopt extends AbstractValues
             $this->values[$option['name']] = $value;
         }
     }
+    
+    /**
+     *
+     * Returns a value.
+     *
+     * @param string $key The key, if any, to get the value of; if null, will
+     * return all values.
+     *
+     * @param string $alt The alternative default value to return if the
+     * requested key does not exist.
+     *
+     * @return mixed The requested value, or the alternative default
+     * value.
+     *
+     */
+    public function get($key = null, $alt = null)
+    {
+        // We need to check if the key we're asking for is an alias
+        foreach ($this->options as $option) {
+            if (!empty($option['alias']) && $option['alias'] == $key) {
+                return parent::get($option['name'], $alt);
+            }
+        }
+
+        // Otherwise use default behaviour
+        return parent::get($key, $alt);
+    }
 }

--- a/tests/src/ContextTest.php
+++ b/tests/src/ContextTest.php
@@ -79,4 +79,29 @@ class ContextTest extends \PHPUnit_Framework_TestCase
         $expect = "The option '-f' requires a parameter.";
         $this->assertSame($expect, $actual->getMessage());
     }
+    
+    /**
+     * Test that when using a getopt alias that whichever order you use
+     * them in the result is the same
+     */
+    public function testGetoptAlias()
+    {
+        $context = $this->newContext(array(
+            'argv' => array(
+                '-f',
+            )
+        ));
+
+        $getopt = $context->getopt(array('f,foo'));
+        $this->assertInstanceOf('Aura\Cli\Context\Getopt', $getopt);
+
+        $this->assertTrue($getopt->get('-f'));
+        $this->assertTrue($getopt->get('--foo'));
+
+        $getopt = $context->getopt(array('foo,f'));
+        $this->assertInstanceOf('Aura\Cli\Context\Getopt', $getopt);
+
+        $this->assertTrue($getopt->get('-f'));
+        $this->assertTrue($getopt->get('--foo'));
+    }
 }

--- a/tests/src/ContextTest.php
+++ b/tests/src/ContextTest.php
@@ -103,5 +103,23 @@ class ContextTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($getopt->get('-f'));
         $this->assertTrue($getopt->get('--foo'));
+        
+        $context = $this->newContext(array(
+            'argv' => array(
+                '-foo',
+            )
+        ));
+
+        $getopt = $context->getopt(array('f,foo'));
+        $this->assertInstanceOf('Aura\Cli\Context\Getopt', $getopt);
+
+        $this->assertTrue($getopt->get('-f'));
+        $this->assertTrue($getopt->get('--foo'));
+
+        $getopt = $context->getopt(array('foo,f'));
+        $this->assertInstanceOf('Aura\Cli\Context\Getopt', $getopt);
+
+        $this->assertTrue($getopt->get('-f'));
+        $this->assertTrue($getopt->get('--foo'));
     }
 }


### PR DESCRIPTION
The option get does not return the correct value when using aliasing and referencing the alias to get the option (even when the value is passed by the alias).

```
$context = $this->newContext(array(
    'argv' => array(
        '-f',
    )
));
$getopt = $context->getopt(array('f,foo'));
$getopt->get('-f'); // Works
$getopt->get('--foo'); // Fails

$context = $this->newContext(array(
    'argv' => array(
        '--foo',
    )
));
$getopt = $context->getopt(array('f,foo'));
$getopt->get('-f'); // Works
$getopt->get('--foo'); // Fails
```
