### PR TITLE
Remove superfluous empty array() initialization.

### DIFF
--- a/src/Help.php
+++ b/src/Help.php
@@ -35,7 +35,7 @@ class Help
      * @var OptionFactory
      *
      */
-    protected $option_factory = array();
+    protected $option_factory;
 
     /**
      *


### PR DESCRIPTION
$option_factory is a member variable which holds an object of type OptionFactory passed into the constructor.  Initializing it to an empty array, while harmless, is not needed.

Existing unit tests should cover this, and pass with the change installed.
