### PR TITLE
Add support for spaces as separator between longopt and their values

### DIFF
--- a/src/Context/GetoptParser.php
+++ b/src/Context/GetoptParser.php
@@ -215,7 +215,7 @@ class GetoptParser
      * Sets the value for a long option.
      *
      * @param string $input The current input element, e.g. "--foo" or
-     * "--bar=baz".
+     * "--bar=baz" or "--bar baz".
      *
      * @return bool|null
      *
@@ -224,6 +224,11 @@ class GetoptParser
     {
         list($name, $value) = $this->splitLongOptionInput($input);
         $option = $this->getOption($name);
+
+        if ($this->longOptionRequiresValue($option, $value)) {
+            $value = array_shift($this->input);
+        }
+
         return $this->longOptionRequiresValue($option, $value, $name)
             || $this->longOptionRejectsValue($option, $value, $name)
             || $this->setValue($option, trim($value) === '' ? true : $value);
@@ -265,12 +270,14 @@ class GetoptParser
      * @return bool
      *
      */
-    protected function longOptionRequiresValue($option, $value, $name)
+    protected function longOptionRequiresValue($option, $value, $name=null)
     {
         if ($option->param == 'required' && trim($value) === '') {
-            $this->errors[] = new Exception\OptionParamRequired(
-                "The option '$name' requires a parameter."
-            );
+            if ($name) {
+                $this->errors[] = new Exception\OptionParamRequired(
+                    "The option '$name' requires a parameter."
+                );
+            }
             return true;
         }
         return false;

--- a/src/Context/GetoptParser.php
+++ b/src/Context/GetoptParser.php
@@ -270,10 +270,10 @@ class GetoptParser
      * @return bool
      *
      */
-    protected function longOptionRequiresValue($option, $value, $name=null)
+    protected function longOptionRequiresValue($option, $value, $name = null)
     {
         if ($option->param == 'required' && trim($value) === '') {
-            if ($name) {
+            if ($name !== null) {
                 $this->errors[] = new Exception\OptionParamRequired(
                     "The option '$name' requires a parameter."
                 );

--- a/tests/Context/GetoptParserTest.php
+++ b/tests/Context/GetoptParserTest.php
@@ -135,6 +135,7 @@ class GetoptParserTest extends \PHPUnit_Framework_TestCase
         $options = array('foo-bar:');
         $this->getopt_parser->setOptions($options);
 
+        // '=' as separator
         $result = $this->getopt_parser->parseInput(array('--foo-bar=baz'));
         $this->assertTrue($result);
 
@@ -142,6 +143,15 @@ class GetoptParserTest extends \PHPUnit_Framework_TestCase
         $actual = $this->getopt_parser->getValues();
         $this->assertSame($expect, $actual);
 
+        // ' ' as separator
+        $result = $this->getopt_parser->parseInput(array('--foo-bar', 'baz'));
+        $this->assertTrue($result);
+
+        $expect = array('--foo-bar' => 'baz');
+        $actual = $this->getopt_parser->getValues();
+        $this->assertSame($expect, $actual);
+
+        // missing required value
         $result = $this->getopt_parser->parseInput(array('--foo-bar'));
         $this->assertFalse($result);
 


### PR DESCRIPTION
This PR adds the ability to use spaces between longopts and their values following the same way as PHP's built-in getopt function.

see: http://php.net/manual/en/function.getopt.php
