### PR TITLE
Correct getopt() example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ method and the argument position number:
 
 ```php
 <?php
-$getopt = $context->getopt();
+$getopt = $context->getopt($options);
 
 // if the script was invoked with:
 // php script.php arg1 arg2 arg3 arg4


### PR DESCRIPTION
The `$options` parameter was missing, implying it was optional when [it is not](https://github.com/auraphp/Aura.Cli/blob/375504b54dcf8d93f99b18a076ccf1640301bd6c/src/Context.php#L110).
