### PR TITLE
Add test for concatenated short options with an optional argument.

### DIFF
--- a/tests/Context/GetoptParserTest.php
+++ b/tests/Context/GetoptParserTest.php
@@ -311,6 +311,23 @@ class GetoptParserTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expect, $actual->getMessage());
     }
 
+    public function testParse_shortClusterOptional()
+    {
+        $options = array('f', 'z', 'b::');
+        $this->getopt_parser->setOptions($options);
+
+        $result = $this->getopt_parser->parseInput(array('-fzb', 'foo_arg'));
+        $this->assertTrue($result);
+
+        $expect = array(
+            '-f' => true,
+            '-z' => true,
+            '-b' => 'foo_arg',
+        );
+        $actual = $this->getopt_parser->getValues();
+        $this->assertSame($expect, $actual);
+    }
+
     public function testParseAndGet()
     {
         $this->getopt_parser->setOptions(array('#foo', 'foo-bar:', '#bar', 'b', '#baz?', 'z::'));


### PR DESCRIPTION
I believe this test is sufficient for making this feature work, but there might be some edge cases which would warrant more tests for really complete code
coverage and regression testing.  They might include the following:
1. Test for an intentional failure of a required argument.
2. Test for success with absent optional argument.

Partial solution for issue #58.