### PR TITLE
fix shortOptionCapturesValue fails getting 0 or '0'

### DIFF
--- a/src/Context/GetoptParser.php
+++ b/src/Context/GetoptParser.php
@@ -360,7 +360,8 @@ class GetoptParser
     protected function shortOptionCapturesValue($option)
     {
         $value = reset($this->input);
-        $is_value = ! empty($value) && substr($value, 0, 1) != '-';
+        $is_empty =  empty($value) && strlen($value) === 0;
+        $is_value = ! $is_empty && substr($value, 0, 1) != '-';
         if ($is_value) {
             $this->setValue($option, array_shift($this->input));
             return true;

--- a/tests/Context/GetoptParserTest.php
+++ b/tests/Context/GetoptParserTest.php
@@ -224,25 +224,28 @@ class GetoptParserTest extends \PHPUnit_Framework_TestCase
 
     public function testParse_shortRequired()
     {
-        $options = array('f:');
-        $this->getopt_parser->setOptions($options);
+        foreach (array('baz', '0', 0) as $value) {
+            $options = array('f:');
+            $this->getopt_parser->setOptions($options);
 
-        $result = $this->getopt_parser->parseInput(array('-f', 'baz'));
-        $this->assertTrue($result);
+            $result = $this->getopt_parser->parseInput(array('-f', $value));
+            $this->assertTrue($result);
 
-        $expect = array('-f' => 'baz');
-        $actual = $this->getopt_parser->getValues();
-        $this->assertSame($expect, $actual);
+            $expect = array('-f' => $value);
+            $actual = $this->getopt_parser->getValues();
+            $this->assertSame($expect, $actual);
 
-        $result = $this->getopt_parser->parseInput(array('-f'));
-        $this->assertFalse($result);
+            $result = $this->getopt_parser->parseInput(array('-f'));
+            $this->assertFalse($result);
 
-        $errors = $this->getopt_parser->getErrors();
-        $actual = $errors[0];
-        $expect = 'Aura\Cli\Exception\OptionParamRequired';
-        $this->assertInstanceOf($expect, $actual);
-        $expect = "The option '-f' requires a parameter.";
-        $this->assertSame($expect, $actual->getMessage());
+            $errors = $this->getopt_parser->getErrors();
+            $actual = $errors[0];
+            $expect = 'Aura\Cli\Exception\OptionParamRequired';
+            $this->assertInstanceOf($expect, $actual);
+            $expect = "The option '-f' requires a parameter.";
+            $this->assertSame($expect, $actual->getMessage());
+
+        }
     }
 
     public function testParse_shortOptional()


### PR DESCRIPTION
Adds a safer emtpy check in GetoptParser::shortOptionCapturesValue