### PR TITLE
Compensate for modern PHP/PHPUnit incompatibility.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         }
     },
     "require-dev": {
+        "phpunit/phpunit": "~5",
         "aura/di": "~2.0"
     },
     "autoload-dev": {


### PR DESCRIPTION
Modern PHPUnit (versions 7, 8, 9) which might be globally installed will
not work with the unit tests here.  This change installs an older PHPUnit
which will work with them.